### PR TITLE
Allow to specify time in verify

### DIFF
--- a/src/totp.js
+++ b/src/totp.js
@@ -72,8 +72,8 @@ export class TOTP extends OTP {
 
     if (time == null) {
       time = new Date();
-      otp_time = this.now();
     }
+    otp_time = super.generate_otp(Util.timecode(time, this.interval));
 
     if (otp === otp_time) {
       return true;


### PR DESCRIPTION
You were able to provide a second argument with a time but it is not used in the verify function.
It is useful when you want to provide a verification with T and T-1 token to prevent expired token